### PR TITLE
Missing contextual information

### DIFF
--- a/src/modules/util.ts
+++ b/src/modules/util.ts
@@ -196,13 +196,13 @@ export function writeAbort(str: string): void{
 }
 
 export function writeError(str: string): void{
-    console.log(">> ".red + str.trim().replace(/\n/g, "\n>> ".red));
+    console.log(">> ".red + str.trim().replace(/\r/g, '').replace(/\n/g, "\n>> ".red));
 }
 
 export function writeInfo(str: string): void{
-    console.log(">> ".cyan + str.trim().replace(/\n/g, "\n>> ".cyan));
+    console.log(">> ".cyan + str.trim().replace(/\r/g, '').replace(/\n/g, "\n>> ".cyan));
 }
 
 export function writeWarn(str: string): void{
-    console.log(">> ".yellow + str.trim().replace(/\n/g, "\n>> ".yellow));
+    console.log(">> ".yellow + str.trim().replace(/\r/g, '').replace(/\n/g, "\n>> ".yellow));
 }


### PR DESCRIPTION
When writeError method is called passing it a Typescript compilation error message, in Windows it trims all the content in a way that there would be no way to find out where the error happened.
This is more sever when the compilation error has happened due to a error in a dependent file (not the main Typescript file).
It looks like in Windows when the `str` contains "\r" character the `replace(/\n/g,...)` will incorrectly replace the whole string.
